### PR TITLE
Parsed relative URLs are now made absolute

### DIFF
--- a/app/helpers/Markdown.php
+++ b/app/helpers/Markdown.php
@@ -11,6 +11,6 @@ class Markdown
 	public static function parse($text)
 	{
         $basePath = url('');
-		return preg_replace('/href=\"(.*?)\"/', "href=\"$basePath$1\"", (new \Parsedown)->text($text));
+		return preg_replace('/href=\"(\/.*?)\"/', "href=\"$basePath$1\"", (new \Parsedown)->text($text));
 	}
 }

--- a/app/helpers/Markdown.php
+++ b/app/helpers/Markdown.php
@@ -10,6 +10,7 @@ class Markdown
 	 */
 	public static function parse($text)
 	{
-		return (new \Parsedown)->text($text);
+        $basePath = url('');
+		return preg_replace('/href=\"(.*?)\"/', "href=\"$basePath$1\"", (new \Parsedown)->text($text));
 	}
 }

--- a/app/helpers/Markdown.php
+++ b/app/helpers/Markdown.php
@@ -10,7 +10,7 @@ class Markdown
 	 */
 	public static function parse($text)
 	{
-        $basePath = url('');
+		$basePath = url('');
 		return preg_replace('/href=\"(\/.*?)\"/', "href=\"$basePath$1\"", (new \Parsedown)->text($text));
 	}
 }


### PR DESCRIPTION
This is similar to #4. We needed a way to qualify relative paths within markdown (and pass them through the `url()` path helper) while not touching already absolute paths.
