### PR TITLE
Remove checking config value with empty() (only supported in PHP 5.5+)

### DIFF
--- a/app/views/partials/analytics_tracking.blade.php
+++ b/app/views/partials/analytics_tracking.blade.php
@@ -1,4 +1,4 @@
-@if ( ! empty(Config::get("codex.tracking_code")))
+@if ( Config::get("codex.tracking_code") )
 	<script>
 		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Hi, 

I've noticed this when tried to set up Codex on the VM we use in my office (currently bound to PHP 5.4.x), got this error message: 

```
Arbitrary expressions in empty() are allowed in PHP 5.5 only
```

After changing this line, Codex works fine with PHP 5.4 too. 
