### PR TITLE
Various fixes for git driver

### DIFF
--- a/app/repositories/CodexRepositoryGit.php
+++ b/app/repositories/CodexRepositoryGit.php
@@ -269,14 +269,13 @@ class CodexRepositoryGit implements CodexRepositoryInterface
 	{
 		$storagePath = storage_path('codex/'.$manual.'/'.$version);
 		if (!file_exists($storagePath)) {
-			$this->git->clone($this->storagePath.'/'.$manual, $storagePath);
+			$this->files->copyDirectory($this->storagePath.'/'.$manual, $storagePath, 0);
 			$this->git->setRepository($storagePath);
 			$this->git->checkout($version);
 		} else {
 			$this->cache->remember("$manual.$version.checkout", 10, function() use ($manual, $version, $storagePath) {
 				$this->git->setRepository($storagePath);
 				$this->git->pull($storagePath, $version);
-				$this->git->checkout($version);
 			});
 		}
 

--- a/app/repositories/CodexRepositoryGit.php
+++ b/app/repositories/CodexRepositoryGit.php
@@ -275,7 +275,7 @@ class CodexRepositoryGit implements CodexRepositoryInterface
 		} else {
 			$this->cache->remember("$manual.$version.checkout", 10, function() use ($manual, $version, $storagePath) {
 				$this->git->setRepository($storagePath);
-				$this->git->pull($storagePath, $version);
+				$this->git->pull('origin', $version);
 			});
 		}
 

--- a/public/docs/codex/1.1.0/learning-more/storage-drivers.md
+++ b/public/docs/codex/1.1.0/learning-more/storage-drivers.md
@@ -11,7 +11,19 @@ master
 1.0
 ```
 
-You can specify the "git" driver in `codex.php` and Codex will automatically create the versions `master`, `2.0`, `1.1`, and `1.0`.
+You can specify the "git" driver in `app/config/codex.php` and Codex will automatically create the versions `master`, `2.0`, `1.1`, and `1.0`.
+
+Once you have specified the git driver, go into `public/docs` or your configured storage path, and delete all existing documentation.
+
+Next, clone your documentation repository
+
+```
+cd public/docs
+rm -rf ./*
+git clone https://github.com/caffeinated/codex-docs codex
+```
+
+Once this is done, you can navigate your browser to your Codex installation and you'll be greeted with all of your git branches available as documentation versions.
 
 
 ## Creating a custom driver


### PR DESCRIPTION
This fixes the issue where the cloned repository's remote is the local docs repo, and so never gets updated. It also fixes handling of branches, and caches the result of branch lookup to stay performant

See #2 for context
