### PR TITLE
Fixed handling of links

### DIFF
--- a/app/helpers/Markdown.php
+++ b/app/helpers/Markdown.php
@@ -14,10 +14,10 @@ class Markdown
 		$rendered = (new \Parsedown)->text($text);
 
 		// Replace absolute relative paths (paths that start with / but not //)
-		$rendered = preg_replace('/href=\"(\/[^\/].*).md(#?.*?)\"/', "href=\"$basePath$1$2\"", $rendered);
+		$rendered = preg_replace('/href=\"(\/[^\/].+?).md(#?.*?)\"/', "href=\"$basePath$1$2\"", $rendered);
 
 		// Replace relative paths (paths that don't start with / or http://, https://, //, etc)
-		$rendered = preg_replace('/href=\"(?!.*?\/\/)(.*).md(#?.*?)\"/', "href=\"$basePath/$1$2\"", $rendered);
+		$rendered = preg_replace('/href=\"(?!.*?\/\/)(.+?).md(#?.*?)\"/', "href=\"$basePath/$1$2\"", $rendered);
 
 		return $rendered;
 	}

--- a/app/repositories/CodexRepositoryGit.php
+++ b/app/repositories/CodexRepositoryGit.php
@@ -87,11 +87,11 @@ class CodexRepositoryGit extends AbstractCodexRepository
 	{
 		$storagePath = $this->getStoragePath($manual, $version);
 
-		$page = $storagePath.'/'.$page.'.md';
+		$pageFile = $storagePath.'/'.$page.'.md';
 
-		if ($this->files->exists($page)) {
+		if ($this->files->exists($pageFile)) {
 			return $this->cached("$manual.$version.$page",
-				Markdown::parse($this->files->get($page), $manual.'/'.$version.'/'.dirname($page)));
+				Markdown::parse($this->files->get($pageFile), $manual.'/'.$version.'/'.dirname($page)));
 		} else {
 			App::abort(404);
 		}


### PR DESCRIPTION
This PR fixes two issues with the handling of links:
- `CodexRepositoryGit` was passing in full filesystem paths to the `MarkdownHelper`.
- `MarkdownHelper`'s path matching regexp was too greedy, and it misses multiple links on a single line.

You can see both problems in action on niceframework.com. This fix seems to take care of all linking issues, and should be considered for 1.1.1.
