### PR TITLE
set the navigation bars position to fixed

### DIFF
--- a/app/views/partials/navbar.blade.php
+++ b/app/views/partials/navbar.blade.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-inverse" role="navigation">
+<nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
 	<div class="container">
 		<div class="navbar-header">
 			<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">

--- a/public/assets/css/codex.css
+++ b/public/assets/css/codex.css
@@ -8,6 +8,7 @@ body {
 	line-height: 1.5em;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
+	padding-top:61px;
 }
 
 nav ul {
@@ -23,6 +24,16 @@ h1, h2, h3, h4, h5 {
 .navbar {
 	margin-bottom: 0;
 	border-radius: 0;
+}
+
+.toc.affix-top {
+	position: static;
+}
+
+.toc.affix {
+	position: fixed;
+	top: 61px;
+	width: 262px;
 }
 
 .toc {

--- a/public/assets/js/codex.js
+++ b/public/assets/js/codex.js
@@ -1,5 +1,18 @@
 $(document).ready(function() {
 
+	// affix the side menu when it is placed on the left
+	// add listener to remove affix when window is resized below 1000px for responsiveness
+	$(window).resize(function() {
+		if (! $(".toc").length) return;
+
+		if (window.innerWidth > 1000) {
+			$(".toc").affix();
+		} else {
+			$(window).off('.affix');
+			$(".toc").removeClass("affix affix-top").removeData("bs.affix");
+		}
+	}).trigger('resize');
+
 	// Bootstrap the tables
 	$(".documentation table").addClass("table table-striped table-bordered table-hover table-condensed");
 


### PR DESCRIPTION
Solved my own issue #25.

The TOC navigation is now fixed on screen when scrolling. For responsiveness' sake this only affects large screens; small screens will just have the TOC menu at the top.

As a side bonus the top navigation bar now also has a fixed position
